### PR TITLE
Exposed the GetTokenRequest overload that takes the method in the interface.

### DIFF
--- a/src/DevDefined.OAuth/Consumer/IOAuthSession.cs
+++ b/src/DevDefined.OAuth/Consumer/IOAuthSession.cs
@@ -42,6 +42,7 @@ namespace DevDefined.OAuth.Consumer
 		IConsumerRequest Request();
 		IConsumerRequest Request(IToken accessToken);
 		IToken GetRequestToken();
+		IToken GetRequestToken(string method);
 		IToken ExchangeRequestTokenForAccessToken(IToken requestToken);
 		IToken ExchangeRequestTokenForAccessToken(IToken requestToken, string verificationCode);
 		IToken ExchangeRequestTokenForAccessToken(IToken requestToken, string method, string verificationCode);


### PR DESCRIPTION
I wanted to be able to use the IOAuthSession interface for mocking purposes but needed that method.
